### PR TITLE
validate Branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Of course this is one of the things which will obviously never finish, but the r
 - [Jira](https://mauwii.atlassian.net/jira/software/c/projects/APWGR/issues)
 - [MkDocs-Material](https://squidfunk.github.io/mkdocs-material/)
 
-### added soon...
+### will be added soon...
 
 - [FastAPI](https://github.com/Azure-Samples/fastapi-on-azure-functions.git)
 - [Jfrog Platform](https://mauwii.jfrog.io)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,5 @@ stages:
   - stage: mkdocs
     jobs:
       - template: azure-pipelines/jobs/mkdocs-material.yml
-        ${{ if eq(variables.isStable, 'True') }}:
-          parameters:
-            mkdocsDeploy: True
+        parameters:
+          mkdocsDeploy: $(isStable)

--- a/azure-pipelines/jobs/bicep_jobs.yml
+++ b/azure-pipelines/jobs/bicep_jobs.yml
@@ -33,7 +33,7 @@ jobs:
 
   - job: validateBicepCode
     dependsOn: createResourceGroup
-    condition: or(eq(variables.sourceBranchName, 'main'), eq(variables.sourceBranchName, 'stable'))
+    condition: or(eq(variables.isMain, 'True'), eq(variables.isStable, 'True'))
     continueOnError: false
     displayName: Validate Bicep code
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   - job: previewAzureChanges
     dependsOn: createResourceGroup
-    condition: or(eq(variables.sourceBranchName, 'main'), eq(variables.sourceBranchName, 'stable'))
+    condition: or(eq(variables.isMain, 'True'), eq(variables.isStable, 'True'))
     displayName: Preview Azure changes
     continueOnError: false
     steps:
@@ -76,7 +76,7 @@ jobs:
       - lintBicep
       - validateBicepCode
       - previewAzureChanges
-    condition: and(succeeded(), or(eq(variables.sourceBranchName, 'main'), eq(variables.sourceBranchName, 'stable')))
+    condition: and(succeeded(), or(eq(variables.isMain, 'True'), eq(variables.isStable, 'True')))
     steps:
       - template: steps/deploy_bicep.yml
         parameters:

--- a/azure-pipelines/jobs/mkdocs-material.yml
+++ b/azure-pipelines/jobs/mkdocs-material.yml
@@ -6,8 +6,8 @@ parameters:
     type: string
     default: 'site'
   - name: mkdocsDeploy
-    type: boolean
-    default: False
+    type: string
+    default: 'False'
 
 jobs:
   - job: mkdocs

--- a/azure-pipelines/jobs/steps/build_mkdocs.yml
+++ b/azure-pipelines/jobs/steps/build_mkdocs.yml
@@ -2,8 +2,10 @@
 parameters:
   - name: pythonVersion
     type: string
+    default: $(pythonVersion)
   - name: mkdocsSiteDir
     type: string
+    default: 'site'
 
 steps:
   - task: UsePythonVersion@0

--- a/src/requirements-mkdocs-material.txt
+++ b/src/requirements-mkdocs-material.txt
@@ -1,1 +1,1 @@
-mkdocs-git-revision-date-plugin==0.3.2
+mkdocs-git-revision-date-plugin


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a Jira Issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

need to validate that branch protection is working correct now
<!--
- If there's an existing Jira issue for your change, please put it's ID between brackets [like this].
- If there's _not_ an existing Jira issue, nor a issue here on Github, please open one first to make it more likely that this update will be accepted: https://github.com/mauwii/django_devops/issues/new/choose. -->

### What's being changed:

change conditions in bicep_jobs.yml to only fire for /refs/heads/main and /refs/heads/stable
changed mkdocsDeploy parameter from boolean to string
set parameters default to 'False' and when calling the template it's now set to $(isStable)
<!-- Please briefly describe what you have changed and whats the benefit of this change -->
