### PR TITLE
silently continue if resource cannot be deleted

### DIFF
--- a/scripts/cleanupautomation.ps1
+++ b/scripts/cleanupautomation.ps1
@@ -150,7 +150,6 @@ foreach ($AzSubscription in Get-AzSubscription) {
         )
       }
       else {
-
         # Get Resource Lock
         $AzResourceLock = Get-AzResourceLock `
           -ResourceName $AzRgResource.Name `
@@ -159,20 +158,24 @@ foreach ($AzSubscription in Get-AzSubscription) {
 
         # Remove Resource Lock if existing
         if ($AzResourceLock) {
-          Remove-AzResourceLock `
+          Write-Host "Deleting Resource Lock of $($AzRgResource.Name)"
+          [void](Remove-AzResourceLock `
             -LockId $AzResourceLock.LockId `
             -Force:$true `
             -WhatIf:$LocalTest
+          )
         }
-
         # Remove Resource
-        Remove-AzResource `
+        $RmResource = Remove-AzResource `
           -ResourceId $AzRgResource.Id `
           -WhatIf:$LocalTest `
+          -ErrorAction:SilentlyContinue `
           -Force:$true
 
         # Update Deleted Resource Count
-        $DeletedResourceCount++
+        if ($RmResource) {
+          $DeletedResourceCount++
+        }
       }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a Jira Issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

cleanupautomation script broke if resource could not be deleted.

<!--
- If there's an existing Jira issue for your change, please put it's ID between brackets [like this].
- If there's _not_ an existing Jira issue, nor a issue here on Github, please open one first to make it more likely that this update will be accepted: https://github.com/mauwii/django_devops/issues/new/choose. -->

### What's being changed:

cleanupautomation script now silently continues if resource could not be deleted. It also writes a message if a resource lock gets deleted now.
<!-- Please briefly describe what you have changed and whats the benefit of this change -->
