### PR TITLE
Update/cleanupautomation/remove empty resourcegroups

### DIFF
--- a/scripts/cleanupautomation.ps1
+++ b/scripts/cleanupautomation.ps1
@@ -202,7 +202,7 @@ foreach ($AzSubscription in Get-AzSubscription) {
           -Name $AzResourceGroup.ResourceGroupName `
           -WhatIf:$LocalTest
       )
-      # Write Info to Host that ResourceGroup is done
+      # Write Info to Host that ResourceGroup was deleted
       Write-Info `
         -Title "Deleted Resourcegroup" `
         -Value $AzResourceGroup.ResourceGroupName `


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a Jira Issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

After some chats and thinking about it, I came to the conclusion that empty RGs should be deleted as well.

<!--
- If there's an existing Jira issue for your change, please put it's ID between brackets [like this].
- If there's _not_ an existing Jira issue, nor a issue here on Github, please open one first to make it more likely that this update will be accepted: https://github.com/mauwii/django_devops/issues/new/choose. -->

### What's being changed:
- check if Resource Group is empty after cleaning Resources in it
- adding counter for deleted Resource Groups
- renamed missleading Variable
- write info if resource could not be deleted
<!-- Please briefly describe what you have changed and whats the benefit of this change -->
